### PR TITLE
update portaudio to v19.7.0

### DIFF
--- a/io.lmms.LMMS.json
+++ b/io.lmms.LMMS.json
@@ -93,8 +93,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz",
-          "sha256": "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513"
+          "url": "https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz",
+          "sha256": "5af29ba58bbdbb7bbcefaaecc77ec8fc413f0db6f4c4e286c40c3e1b83174fa0"
         }
       ]
     },


### PR DESCRIPTION
also switched to github download url, since http://www.portaudio.com is currently down