### PR TITLE
use built-in ladspa plugins

### DIFF
--- a/io.lmms.LMMS.json
+++ b/io.lmms.LMMS.json
@@ -38,38 +38,6 @@
         "merge-dirs": "ladspa;dssi;lv2;lxvst;vst3",
         "subdirectories": true,
         "no-autodownload": true
-    },
-    "org.freedesktop.LinuxAudio.Plugins.CAPS": {
-        "directory": "extensions/Plugins/CAPS",
-        "version": "21.08",
-        "add-ld-path": "lib",
-        "merge-dirs": "ladspa",
-        "autodelete": false,
-        "subdirectories": true
-    },
-    "org.freedesktop.LinuxAudio.Plugins.CMT": {
-        "directory": "extensions/Plugins/CMT",
-        "version": "21.08",
-        "add-ld-path": "lib",
-        "merge-dirs": "ladspa",
-        "autodelete": false,
-        "subdirectories": true
-    },
-    "org.freedesktop.LinuxAudio.LadspaPlugins.TAP": {
-        "directory": "extensions/Plugins/TAP",
-        "version": "21.08",
-        "add-ld-path": "lib",
-        "merge-dirs": "ladspa",
-        "autodelete": false,
-        "subdirectories": true
-    },
-    "org.freedesktop.LinuxAudio.LadspaPlugins.swh": {
-        "directory": "extensions/Plugins/swh",
-        "version": "21.08",
-        "add-ld-path": "lib",
-        "merge-dirs": "ladspa",
-        "autodelete": false,
-        "subdirectories": true
     }
   },
   "cleanup": [
@@ -213,10 +181,6 @@
       "buildsystem": "cmake-ninja",
       "config-opts": [
         "-DWANT_QT5=ON",
-        "-DWANT_CMT=OFF",
-        "-DWANT_CAPS=OFF",
-        "-DWANT_TAP=OFF",
-        "-DWANT_SWH=OFF",
         "-DWANT_VST=OFF"
       ],
       "cleanup": [


### PR DESCRIPTION
Currently we use the ladspa plugin builds from flathub. This seems wise at first to avoid duplicate builds, but it turns out LMMS bundles custom versions of the plugins, which differ from the flathub builds (at least for caps, not sure about the others yet).

Using the flathub plugin builds leads to problems when opening projects created with other builds of LMMS (provided by os repos or appimage).
See: https://github.com/flathub/io.lmms.LMMS/issues/30

So for better compatibility we should switch to use the lmms provided plugin versions.