### PR TITLE
remove carla plugins

### DIFF
--- a/io.lmms.LMMS.json
+++ b/io.lmms.LMMS.json
@@ -31,12 +31,12 @@
   ],
   "add-extensions": {
     "org.freedesktop.LinuxAudio.Plugins": {
-        "directory": "extensions/Plugins",
-        "version": "21.08",
-        "add-ld-path": "lib",
-        "merge-dirs": "ladspa;dssi;lv2;lxvst;vst3",
-        "subdirectories": true,
-        "no-autodownload": true
+      "directory": "extensions/Plugins",
+      "version": "21.08",
+      "add-ld-path": "lib",
+      "merge-dirs": "ladspa;dssi;lv2;lxvst;vst3",
+      "subdirectories": true,
+      "no-autodownload": true
     }
   },
   "cleanup": [
@@ -67,14 +67,14 @@
     },
     "shared-modules/linux-audio/fluidsynth2.json",
     {
-      "name" : "pyqt5",
-      "config-opts" : [
+      "name": "pyqt5",
+      "config-opts": [
         "--disable-static",
         "--enable-x11"
       ],
-      "sources" : [
+      "sources": [
         {
-          "type" : "archive",
+          "type": "archive",
           "url": "https://files.pythonhosted.org/packages/4d/81/b9a66a28fb9a7bbeb60e266f06ebc4703e7e42b99e3609bf1b58ddd232b9/PyQt5-5.14.2.tar.gz",
           "sha256": "bd230c6fd699eabf1ceb51e13a8b79b74c00a80272c622427b80141a22269eb0"
         },
@@ -86,14 +86,14 @@
           "dest-filename": "configure"
         }
       ],
-      "modules" : [
+      "modules": [
         {
-          "name" : "sip",
-          "sources" : [
+          "name": "sip",
+          "sources": [
             {
-              "type" : "archive",
-              "url" : "https://distfiles.macports.org/py-sip/sip-4.19.22.tar.gz",
-              "sha256" : "e1b768824ec1a2ee38dd536b6b6b3d06de27b00a2f5f55470d1b512306e3be45"
+              "type": "archive",
+              "url": "https://distfiles.macports.org/py-sip/sip-4.19.22.tar.gz",
+              "sha256": "e1b768824ec1a2ee38dd536b6b6b3d06de27b00a2f5f55470d1b512306e3be45"
             },
             {
               "type": "script",
@@ -137,6 +137,9 @@
           "url": "https://github.com/falkTX/Carla/archive/v2.4.1.tar.gz",
           "sha256": "bbb188a672ea8871b11648d36770ba013497d03407ca9c73ed68429016f7536f"
         }
+      ],
+      "cleanup": [
+        "/lib/vst/carla.vst/"
       ]
     },
     "shared-modules/linux-audio/stk.json",

--- a/io.lmms.LMMS.json
+++ b/io.lmms.LMMS.json
@@ -139,7 +139,8 @@
         }
       ],
       "cleanup": [
-        "/lib/vst/carla.vst/"
+        "/lib/vst/carla.vst/",
+        "/lib/lv2/carla.lv2/"
       ]
     },
     "shared-modules/linux-audio/stk.json",


### PR DESCRIPTION
Carla builds itself (Patchbay and Rack) as vst/lv2 plugins. However since LMMS does not take advantage of them (but uses Carla directly), they can be removed to reduce flatpak size.